### PR TITLE
[WIP] Support transition prefix

### DIFF
--- a/src/supported-value.js
+++ b/src/supported-value.js
@@ -1,10 +1,25 @@
 import isInBrowser from 'is-in-browser'
 import prefix from './prefix'
+import supportedProperty from './supported-property'
 
 const cache = {}
+const transitionProperties = [
+  'transition',
+  'transition-property',
+  '-webkit-transition',
+  '-webkit-transition-property',
+]
+// Matches all properties in transition and transition-property.
+const transPropsRegExp = /(^\s*\w+)|, (\s*\w+)/g
 let el
 
 if (isInBrowser) el = document.createElement('p')
+
+function prefixTransitionCallback(match, p1, p2) {
+  if (p1 === 'all') return 'all'
+  if (p2 === 'all') return ', all'
+  return p1 ? supportedProperty(p1) : `, ${supportedProperty(p2)}`
+}
 
 /**
  * Returns prefixed value if needed. Returns `false` if value is not supported.
@@ -36,8 +51,12 @@ export default function supportedValue(property, value) {
     return false
   }
 
+  // Prefix transition properties.
+  if (transitionProperties.indexOf(property) !== -1) {
+    cache[cacheKey] = value.replace(transPropsRegExp, prefixTransitionCallback)
+  }
   // Value is supported as it is.
-  if (el.style[property] === value) {
+  else if (el.style[property] === value) {
     cache[cacheKey] = value
   }
   else {

--- a/test/index.js
+++ b/test/index.js
@@ -54,3 +54,13 @@ test('unknown value', function (assert) {
 test('bad "content" value', function (assert) {
   assert.equal(cssVendor.supportedValue('content', 'bar'), false)
 })
+
+test('known transition value prefixed', function (assert) {
+  var value = cssVendor.supportedValue('transition', 'all 100ms ease, transform 200ms linear')
+  assert.equal(value, 'all 100ms ease, ' + cssVendor.prefix.css + 'transform 200ms linear')
+})
+
+test('known transition-property value prefixed', function (assert) {
+  var value = cssVendor.supportedValue('transition-property', 'all, transform')
+  assert.equal(value, 'all, ' + cssVendor.prefix.css + 'transform')
+})


### PR DESCRIPTION
This PR fixes https://github.com/cssinjs/jss/issues/317 and https://github.com/cssinjs/jss/issues/300 by adding support for prefixing properties inside `transition` and `transition-property`. 

This PR uses a regular expression to match and replace properties with their prefixed version. Tests were added that should pass in browsers needing to prefix the `transform` property: Android stock browsers, UC Browser on Android, Safari IOS 8, and IE9. 

_Note: IE9 doesn't support css transitions, but the tests will pass because the tests only check for correctly prefixing the values._

The test setup is currently not ideal see https://github.com/cssinjs/jss/issues/89. Maybe we should do something like detecting the browser (e.g. using `bowser`) and giving out only relevant tests.