### PR TITLE
Better cache prefill

### DIFF
--- a/src/supported-property.js
+++ b/src/supported-property.js
@@ -19,7 +19,7 @@ if (isInBrowser) {
    */
   const computed = window.getComputedStyle(document.documentElement, '')
   for (const key in computed) {
-    cache[computed[key]] = computed[key]
+    if (!isNaN(key)) cache[computed[key]] = computed[key]
   }
 }
 


### PR DESCRIPTION
To check current status of cache prefill open the following fiddle and check the console.
https://jsfiddle.net/wikiwi/xodLuxpw/4/

The cache contains the desired prefill but additionally a lot of irrelevant keys and values making `supported-property` sometimes return a wrong result. In my case I was wondering why the property `all` was a supported property in IE, even though IE doesn't expose it anywhere in its API.

This PR simply prevents the irrelevant keys from being added to the cache, similar to this fiddle: 
https://jsfiddle.net/wikiwi/xodLuxpw/5/