### PR TITLE
Test suite for supportedProperty

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "license": "MIT",
   "main": "./lib/index",
   "devDependencies": {
+    "autoprefixer": "^6.7.3",
     "babel-cli": "^6.5.1",
     "babel-core": "^6.5.1",
     "babel-eslint": "^6.1.2",
@@ -47,7 +48,7 @@
     "babel-plugin-transform-es3-property-literals": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
-    "caniuse-support": "^0.2.0",
+    "caniuse-support": "^0.4.0",
     "cross-env": "^3.1.3",
     "es5-shim": "^4.5.9",
     "eslint": "^2.8.0",
@@ -71,6 +72,7 @@
     "karma-webpack": "^1.7.0",
     "lint-staged": "^3.0.1",
     "mocha": "^3.0.2",
+    "postcss-js": "^0.2.0",
     "pre-commit": "^1.1.3",
     "rimraf": "^2.5.4",
     "webpack": "^1.12.2"

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -4,6 +4,7 @@ import expect from 'expect.js'
 import {getSupport, currentBrowser} from 'caniuse-support'
 
 import {prefix, supportedProperty, supportedValue} from './index'
+import propertyPrefixFixture from '../test/fixtures/property-prefix'
 
 const msg = `Detected browser: ${currentBrowser.id} ${currentBrowser.version}`
 console.log(msg) // eslint-disable-line no-console
@@ -28,12 +29,10 @@ describe('css-vendor', () => {
       expect(supportedProperty('display')).to.be('display')
     })
 
-    it('should prefix if needed', function () {
-      const {level, needPrefix} = getSupport('transforms2d')
-      if (level === 'none' || level === 'unknown') this.skip()
-      const prop = needPrefix ? `${prefix.css}transform` : 'transform'
-      expect(supportedProperty('transform')).to.be(prop)
-    })
+    for (const property in propertyPrefixFixture) {
+      it(`should prefix ${property} if needed [${currentBrowser.id} ${currentBrowser.version}]`,
+        () => expect(supportedProperty(property)).to.be(propertyPrefixFixture[property]))
+    }
 
     it('should return false', () => {
       expect(supportedProperty('xxx')).to.be(false)

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,5 @@
+export function dashify(str) {
+  return str.replace(/([A-Z])/g, '-$1')
+    .replace(/^ms-/, '-ms-')
+    .toLowerCase()
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,5 +29,8 @@ module.exports = {
         test: /\.json$/
       }
     ]
+  },
+  node: {
+    fs: "empty",
   }
 }


### PR DESCRIPTION
Test cases are taken from http://shouldiprefix.com/ marked as `use prefixes`.  Additionally the transition property is tested.

The following issues have been discovered and fixed:

- Fixes issue when prefixing the filter property
- Fallback to ms prefix on edge