### PR TITLE
Correctly Detect Vendor Prefix for Edge

### DIFF
--- a/src/prefix.js
+++ b/src/prefix.js
@@ -29,6 +29,12 @@ if (isInBrowser) {
       break
     }
   }
+
+  // Correctly detect the Edge browser.
+  if (js === 'Webkit' && 'msHyphens' in style) {
+    js = 'ms'
+    css = jsCssMap.ms
+  }
 }
 
 /**


### PR DESCRIPTION
Edge kicked out the `-ms-transform` property and cannot correctly be detected only by checking the `transform` property. I considered using a different css property but I couldn't find one that was more suitable than using `transform`. The closest candidate was `user-select` but then we would not correctly detect some older browsers like IE 9 and Opera mobile..

This PR adds an extra check that corrects the false detection.
Reduces failing tests by 11! 

232 to go! ;-)