### PR TITLE
Fix failing tests Part 1

### DIFF
--- a/src/plugins/block-logical-old.js
+++ b/src/plugins/block-logical-old.js
@@ -1,0 +1,20 @@
+import prefix from '../prefix'
+import camelize from '../camelize'
+
+// Support old block-logical syntax.
+// See https://github.com/postcss/autoprefixer/issues/324.
+export default {
+  supportedProperty: (prop, style) => {
+    let newProp;
+    if (prop.match(/^(border|margin|padding)-block-start/)) {
+      newProp = prop.replace('-block-start', '-before')
+    }
+    if (prop.match(/^(border|margin|padding)-block-end/)) {
+      newProp = prop.replace('-block-end', '-after')
+    }
+    if (!newProp) {
+      return false
+    }
+    return prefix.js + camelize(`-${newProp}`) in style ? prefix.css + newProp : false
+  },
+}

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,0 +1,7 @@
+const plugins = [
+]
+
+export const supportedPropertyPlugins = plugins
+  .filter(p => p.supportedProperty)
+  .map(p => p.supportedProperty)
+

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,4 +1,7 @@
+import maskBorderOld from "./mask-border-old"
+
 const plugins = [
+  maskBorderOld,
 ]
 
 export const supportedPropertyPlugins = plugins

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,6 +1,10 @@
+import blockLogicalOld from "./block-logical-old"
+import inlineLogicalOld from "./inline-logical-old"
 import maskBorderOld from "./mask-border-old"
 
 const plugins = [
+  blockLogicalOld,
+  inlineLogicalOld,
   maskBorderOld,
 ]
 

--- a/src/plugins/inline-logical-old.js
+++ b/src/plugins/inline-logical-old.js
@@ -1,0 +1,14 @@
+import prefix from '../prefix'
+import camelize from '../camelize'
+
+// Support old inline-logical syntax.
+// See https://github.com/postcss/autoprefixer/issues/324.
+export default {
+  supportedProperty: (prop, style) => {
+    if (prop.match(/^(border|margin|padding)-inline/)) {
+      const newProp = prop.replace('-inline', '')
+      return prefix.js + camelize(`-${newProp}`) in style ? prefix.css + newProp : false
+    }
+    return false
+  }
+}

--- a/src/plugins/mask-border-old.js
+++ b/src/plugins/mask-border-old.js
@@ -1,0 +1,14 @@
+import prefix from '../prefix'
+import camelize from '../camelize'
+
+// Support old mask-border syntax.
+// See https://github.com/postcss/autoprefixer/issues/502.
+export default {
+  supportedProperty: (prop, style) => {
+    if (prop.match(/^mask-border/)) {
+      const newProp = prop.replace(/^mask-border/, 'mask-box-image')
+      return prefix.js + camelize(`-${newProp}`) in style ? prefix.css + newProp : false
+    }
+    return false
+  }
+}


### PR DESCRIPTION
This PR introduces a plugin architecture and adds support for old `mask-border` syntax and old `logical props` syntax.

Reduces failing tests down to 149 :-)