### PR TITLE
Fix failing tests 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:dist:max": "cross-env NODE_ENV=development webpack src/index.js dist/css-vendor.js",
     "build:dist:min": "cross-env NODE_ENV=production webpack src/index.js dist/css-vendor.min.js",
     "clean": "rimraf {lib,dist,tests,tmp}/*",
-    "lint": "eslint ./src",
+    "lint": "eslint ./src ./test",
     "lint:staged": "lint-staged",
     "test": "cross-env NODE_ENV=test karma start --single-run ",
     "test:watch": "cross-env NODE_ENV=test karma start",

--- a/src/pascalize.js
+++ b/src/pascalize.js
@@ -1,0 +1,12 @@
+import camelize from './camelize'
+
+/**
+ * Convert dash separated strings to pascal cased.
+ *
+ * @param {String} str
+ * @return {String}
+ */
+export default function pascalize(str) {
+  return camelize(`-${str}`)
+}
+

--- a/src/plugins/block-logical-old.js
+++ b/src/plugins/block-logical-old.js
@@ -1,5 +1,5 @@
 import prefix from '../prefix'
-import camelize from '../camelize'
+import pascalize from '../pascalize'
 
 // Support old block-logical syntax.
 // See https://github.com/postcss/autoprefixer/issues/324.
@@ -15,6 +15,6 @@ export default {
     if (!newProp) {
       return false
     }
-    return prefix.js + camelize(`-${newProp}`) in style ? prefix.css + newProp : false
+    return prefix.js + pascalize(newProp) in style ? prefix.css + newProp : false
   },
 }

--- a/src/plugins/break-props-old.js
+++ b/src/plugins/break-props-old.js
@@ -1,5 +1,5 @@
 import prefix from '../prefix'
-import camelize from '../camelize'
+import pascalize from '../pascalize'
 
 // Support old break-* props syntax.
 // http://caniuse.com/#feat=multicolumn
@@ -9,11 +9,11 @@ export default {
   supportedProperty: (prop, style) => {
     if (prop.match(/^break-/)) {
       if (prefix.js === 'Webkit') {
-        const jsProp = `WebkitColumn${camelize(`-${prop}`)}`
+        const jsProp = `WebkitColumn${pascalize(prop)}`
         return jsProp in style ? `${prefix.css}column-${prop}` : false
       }
       else if (prefix.js === 'Moz') {
-        const jsProp = `page${camelize(`-${prop}`)}`
+        const jsProp = `page${pascalize(prop)}`
         return jsProp in style ? `page-${prop}` : false
       }
     }

--- a/src/plugins/break-props-old.js
+++ b/src/plugins/break-props-old.js
@@ -1,0 +1,22 @@
+import prefix from '../prefix'
+import camelize from '../camelize'
+
+// Support old break-* props syntax.
+// http://caniuse.com/#feat=multicolumn
+// https://github.com/postcss/autoprefixer/issues/491
+// https://github.com/postcss/autoprefixer/issues/177
+export default {
+  supportedProperty: (prop, style) => {
+    if (prop.match(/^break-/)) {
+      if (prefix.js === 'Webkit') {
+        const jsProp = `WebkitColumn${camelize(`-${prop}`)}`
+        return jsProp in style ? `${prefix.css}column-${prop}` : false
+      }
+      else if (prefix.js === 'Moz') {
+        const jsProp = `page${camelize(`-${prop}`)}`
+        return jsProp in style ? `page-${prop}` : false
+      }
+    }
+    return false
+  }
+}

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,11 +1,13 @@
 import blockLogicalOld from './block-logical-old'
 import inlineLogicalOld from './inline-logical-old'
 import maskBorderOld from './mask-border-old'
+import breakPropsOld from './break-props-old'
 
 const plugins = [
   blockLogicalOld,
   inlineLogicalOld,
   maskBorderOld,
+  breakPropsOld,
 ]
 
 export const supportedPropertyPlugins = plugins

--- a/src/plugins/inline-logical-old.js
+++ b/src/plugins/inline-logical-old.js
@@ -1,5 +1,5 @@
 import prefix from '../prefix'
-import camelize from '../camelize'
+import pascalize from '../pascalize'
 
 // Support old inline-logical syntax.
 // See https://github.com/postcss/autoprefixer/issues/324.
@@ -7,7 +7,7 @@ export default {
   supportedProperty: (prop, style) => {
     if (prop.match(/^(border|margin|padding)-inline/)) {
       const newProp = prop.replace('-inline', '')
-      return prefix.js + camelize(`-${newProp}`) in style ? prefix.css + newProp : false
+      return prefix.js + pascalize(newProp) in style ? prefix.css + newProp : false
     }
     return false
   }

--- a/src/plugins/mask-border-old.js
+++ b/src/plugins/mask-border-old.js
@@ -1,5 +1,5 @@
 import prefix from '../prefix'
-import camelize from '../camelize'
+import pascalize from '../pascalize'
 
 // Support old mask-border syntax.
 // See https://github.com/postcss/autoprefixer/issues/502.
@@ -7,7 +7,7 @@ export default {
   supportedProperty: (prop, style) => {
     if (prop.match(/^mask-border/)) {
       const newProp = prop.replace(/^mask-border/, 'mask-box-image')
-      return prefix.js + camelize(`-${newProp}`) in style ? prefix.css + newProp : false
+      return prefix.js + pascalize(newProp) in style ? prefix.css + newProp : false
     }
     return false
   }

--- a/src/supported-property.js
+++ b/src/supported-property.js
@@ -1,6 +1,7 @@
 import isInBrowser from 'is-in-browser'
 import prefix from './prefix'
 import camelize from './camelize'
+import pascalize from './pascalize'
 import {supportedPropertyPlugins} from './plugins'
 
 let el
@@ -30,7 +31,7 @@ const propertyDetectors = [
   // Test if property is supported as it is.
   (prop, style) => (camelize(prop) in style ? prop : false),
   // Test if property is supported with vendor prefix.
-  (prop, style) => (prefix.js + camelize(`-${prop}`) in style ? prefix.css + prop : false),
+  (prop, style) => (prefix.js + pascalize(prop) in style ? prefix.css + prop : false),
   ...supportedPropertyPlugins
 ]
 

--- a/test/fixtures/property-prefix.js
+++ b/test/fixtures/property-prefix.js
@@ -19,7 +19,9 @@ const isNotSupported = (o) =>
     o.property === "object-position" && o.notes.indexOf(1) > -1 ||
     // http://caniuse.com/#feat=multicolumn
     // https://bugzilla.mozilla.org/show_bug.cgi?id=616436
-    o.property === "column-span" && currentBrowser.id === "firefox"
+    o.property === "column-span" && currentBrowser.id === "firefox" ||
+    // http://caniuse.com/#feat=css-masks
+    o.property.match(/^mask-/) && o.notes.indexOf(2) > -1
 
 function generateFixture() {
   const fixture = {}

--- a/test/fixtures/property-prefix.js
+++ b/test/fixtures/property-prefix.js
@@ -15,7 +15,7 @@ const skipProperties = [
 
 const isNotSupported = (o) =>
     o.level === "none" ||
-    // http://caniuse.com/#search=object-position
+    // http://caniuse.com/#feat=object-fit
     o.property === "object-position" && o.notes.indexOf(1) > -1
 
 function generateFixture() {

--- a/test/fixtures/property-prefix.js
+++ b/test/fixtures/property-prefix.js
@@ -10,29 +10,29 @@ const prefixer = postcssJs.sync([ap])
 
 const skipProperties = [
   // caniuse doesn't cover this property and spec might drop this: https://www.w3.org/TR/css-fonts-3/.
-  "font-language-override",
+  'font-language-override',
 ]
 
 const isNotSupported = (o) =>
-    o.level === "none" ||
+    o.level === 'none' ||
     // http://caniuse.com/#feat=object-fit
-    o.property === "object-position" && o.notes.indexOf(1) > -1 ||
+    o.property === 'object-position' && o.notes.indexOf(1) > -1 ||
     // http://caniuse.com/#feat=multicolumn
     // https://bugzilla.mozilla.org/show_bug.cgi?id=616436
-    o.property === "column-span" && currentBrowser.id === "firefox" ||
+    o.property === 'column-span' && currentBrowser.id === 'firefox' ||
     // http://caniuse.com/#feat=css-masks
     o.property.match(/^mask-/) && o.notes.indexOf(2) > -1
 
 function generateFixture() {
   const fixture = {}
-  const supported = Object.keys(data).
+  Object.keys(data).
     // Filters autoprefixer data to include only property prefix related entries.
     filter(s => s.match(/^[^:@].*$/g)).
     filter(s => data[s].props === undefined).
     filter(s => skipProperties.indexOf(s) < 0).
     // TODO: Remove the following line when this is resolved: https://github.com/Fyrd/caniuse/issues/3070.
-    filter(s => ["css3-cursors-grab", "css-text-spacing"].indexOf(data[s].feature) < 0).
-    map(s => ({ property: s, feature: data[s].feature, ...getSupport(data[s].feature) })).
+    filter(s => ['css3-cursors-grab', 'css-text-spacing'].indexOf(data[s].feature) < 0).
+    map(s => ({property: s, feature: data[s].feature, ...getSupport(data[s].feature)})).
     // No support in caniuse db means no support for the spec, but
     // no support in css-vendor means no browser support at all for the particular property,
     // therefore we cannot test with the caniuse data for these cases.

--- a/test/fixtures/property-prefix.js
+++ b/test/fixtures/property-prefix.js
@@ -16,7 +16,10 @@ const skipProperties = [
 const isNotSupported = (o) =>
     o.level === "none" ||
     // http://caniuse.com/#feat=object-fit
-    o.property === "object-position" && o.notes.indexOf(1) > -1
+    o.property === "object-position" && o.notes.indexOf(1) > -1 ||
+    // http://caniuse.com/#feat=multicolumn
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=616436
+    o.property === "column-span" && currentBrowser.id === "firefox"
 
 function generateFixture() {
   const fixture = {}


### PR DESCRIPTION
This PR focuses on the current Firefox browser v51 and including the PRs I sent over at autoprefixer and caniuse db will let it pass the test suite.

- Excludes `column-span` for firefox from test suite
- Excludes `mask-*` props for older firefox from test suite
- Supports former `break-*` props for firefox
- Supports non standard `break-*` props for webkit browsers