### PR TITLE
Fix failing tests 3

### DIFF
--- a/src/plugins/clip-path.js
+++ b/src/plugins/clip-path.js
@@ -1,0 +1,21 @@
+import prefix from '../prefix'
+import pascalize from '../pascalize'
+
+// clip-path has basic support in webkit without prefix for svg documents
+// but in other cases it might need a prefix. We can resort to value testing.
+// See https://developer.mozilla.org/de/docs/Web/CSS/clip-path
+export default {
+  noPrefill: ['clip-path'],
+  supportedProperty: (prop, style) => {
+    if (prop === 'clip-path' && prefix.js === 'Webkit') {
+      style.clipPath = 'inset(10px 20px 30px 40px)'
+      const value = style.clipPath
+      style.clipPath = ''
+      if (value) return prop
+      if (prefix.js + pascalize(prop) in style) {
+        return prefix.css + prop
+      }
+    }
+    return false
+  }
+}

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,3 +1,4 @@
+import mask from './mask'
 import unprefixed from './unprefixed'
 import prefixed from './prefixed'
 import blockLogicalOld from './block-logical-old'
@@ -6,6 +7,7 @@ import maskBorderOld from './mask-border-old'
 import breakPropsOld from './break-props-old'
 
 const plugins = [
+  mask,
   unprefixed,
   prefixed,
   blockLogicalOld,
@@ -24,3 +26,4 @@ export const noPrefill = plugins
     a.push(...p.noPrefill)
     return a
   }, [])
+

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,4 +1,5 @@
 import mask from './mask'
+import writingMode from './writing-mode'
 import unprefixed from './unprefixed'
 import prefixed from './prefixed'
 import blockLogicalOld from './block-logical-old'
@@ -8,6 +9,7 @@ import breakPropsOld from './break-props-old'
 
 const plugins = [
   mask,
+  writingMode,
   unprefixed,
   prefixed,
   blockLogicalOld,

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -17,3 +17,10 @@ const plugins = [
 export const propertyDetectors = plugins
   .filter(p => p.supportedProperty)
   .map(p => p.supportedProperty)
+
+export const noPrefill = plugins
+  .filter(p => p.noPrefill)
+  .reduce((a, p) => {
+    a.push(...p.noPrefill)
+    return a
+  }, [])

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,16 +1,19 @@
+import unprefixed from './unprefixed'
+import prefixed from './prefixed'
 import blockLogicalOld from './block-logical-old'
 import inlineLogicalOld from './inline-logical-old'
 import maskBorderOld from './mask-border-old'
 import breakPropsOld from './break-props-old'
 
 const plugins = [
+  unprefixed,
+  prefixed,
   blockLogicalOld,
   inlineLogicalOld,
   maskBorderOld,
   breakPropsOld,
 ]
 
-export const supportedPropertyPlugins = plugins
+export const propertyDetectors = plugins
   .filter(p => p.supportedProperty)
   .map(p => p.supportedProperty)
-

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,5 +1,6 @@
 import mask from './mask'
 import writingMode from './writing-mode'
+import clipPath from './clip-path'
 import unprefixed from './unprefixed'
 import prefixed from './prefixed'
 import blockLogicalOld from './block-logical-old'
@@ -10,6 +11,7 @@ import breakPropsOld from './break-props-old'
 const plugins = [
   mask,
   writingMode,
+  clipPath,
   unprefixed,
   prefixed,
   blockLogicalOld,

--- a/src/plugins/mask.js
+++ b/src/plugins/mask.js
@@ -1,0 +1,22 @@
+import prefix from '../prefix'
+import pascalize from '../pascalize'
+import camelize from '../camelize'
+
+// mask property support cannot be directly detected in webkit browsers,
+// but we can use a longhand property instead.
+export default {
+  noPrefill: ['mask'],
+  supportedProperty: (prop, style) => {
+    if (prop === 'mask' && prefix.js === 'Webkit') {
+      const longhand = 'mask-image'
+      if (camelize(longhand) in style) {
+        return prop
+      }
+      if (prefix.js + pascalize(longhand) in style) {
+        return prefix.css + prop
+      }
+    }
+    return false
+  }
+}
+

--- a/src/plugins/prefixed.js
+++ b/src/plugins/prefixed.js
@@ -1,0 +1,9 @@
+import prefix from '../prefix'
+import pascalize from '../pascalize'
+
+// Test if property is supported with vendor prefix.
+export default {
+  supportedProperty: (prop, style) =>
+    (prefix.js + pascalize(prop) in style ? prefix.css + prop : false),
+}
+

--- a/src/plugins/unprefixed.js
+++ b/src/plugins/unprefixed.js
@@ -1,0 +1,8 @@
+import camelize from '../camelize'
+
+// Test if property is supported as it is.
+// Camelization is required because we can't test using
+// css syntax for e.g. in FF.
+export default {
+  supportedProperty: (prop, style) => (camelize(prop) in style ? prop : false),
+}

--- a/src/plugins/writing-mode.js
+++ b/src/plugins/writing-mode.js
@@ -1,0 +1,21 @@
+import prefix from '../prefix'
+import pascalize from '../pascalize'
+
+// writing-mode has basic support in webkit without prefix for svg documents
+// but in other cases it might need a prefix. We can resort to value testing.
+// See https://developer.mozilla.org/de/docs/Web/CSS/writing-mode
+export default {
+  noPrefill: ['writing-mode'],
+  supportedProperty: (prop, style) => {
+    if (prop === 'writing-mode' && prefix.js === 'Webkit') {
+      style.writingMode = 'horizontal-tb'
+      const value = style.writingMode
+      style.writingMode = ''
+      if (value) return prop
+      if (prefix.js + pascalize(prop) in style) {
+        return prefix.css + prop
+      }
+    }
+    return false
+  }
+}

--- a/src/supported-property.js
+++ b/src/supported-property.js
@@ -1,5 +1,5 @@
 import isInBrowser from 'is-in-browser'
-import {propertyDetectors} from './plugins'
+import {propertyDetectors, noPrefill} from './plugins'
 
 let el
 const cache = {}
@@ -20,6 +20,10 @@ if (isInBrowser) {
   for (const key in computed) {
     if (!isNaN(key)) cache[computed[key]] = computed[key]
   }
+
+  // Properties that cannot be correctly detected using the
+  // cache prefill method.
+  noPrefill.forEach(x => delete cache[x])
 }
 
 /**

--- a/src/supported-property.js
+++ b/src/supported-property.js
@@ -1,8 +1,5 @@
 import isInBrowser from 'is-in-browser'
-import prefix from './prefix'
-import camelize from './camelize'
-import pascalize from './pascalize'
-import {supportedPropertyPlugins} from './plugins'
+import {propertyDetectors} from './plugins'
 
 let el
 const cache = {}
@@ -24,16 +21,6 @@ if (isInBrowser) {
     if (!isNaN(key)) cache[computed[key]] = computed[key]
   }
 }
-
-const propertyDetectors = [
-  // Camelization is required because we can't test using
-  // css syntax for e.g. in FF.
-  // Test if property is supported as it is.
-  (prop, style) => (camelize(prop) in style ? prop : false),
-  // Test if property is supported with vendor prefix.
-  (prop, style) => (prefix.js + pascalize(prop) in style ? prefix.css + prop : false),
-  ...supportedPropertyPlugins
-]
 
 /**
  * Test if a property is supported, returns supported property with vendor

--- a/test/fixtures/property-prefix.js
+++ b/test/fixtures/property-prefix.js
@@ -21,7 +21,10 @@ const isNotSupported = (o) =>
     // https://bugzilla.mozilla.org/show_bug.cgi?id=616436
     o.property === 'column-span' && currentBrowser.id === 'firefox' ||
     // http://caniuse.com/#feat=css-masks
-    o.property.match(/^mask-/) && o.notes.indexOf(2) > -1
+    o.property.match(/^mask-/) && o.notes.indexOf(2) > -1 ||
+    // http://caniuse.com/#feat=text-decoration
+    o.property === 'text-decoration-skip' && o.notes.indexOf(4) > -1 ||
+    o.property === 'text-decoration-style' && o.notes.indexOf(2) > -1
 
 function generateFixture() {
   const fixture = {}


### PR DESCRIPTION
This PR focuses on passing Chrome v56, Opera v43 and Safari v10. 

- Excludes `text-decoration` for browsers with no support from test suite
- Supports `mask` property for webkit/blink based browsers
- Supports `writing-mode` property for webkit/blink based browsers
- Supports `clip-path` property for webkit/blink based browsers

Related PR: https://github.com/Fyrd/caniuse/pull/3198

Less than 91 failing tests left.