### PR TITLE
Fix failing tests 4

### DIFF
--- a/src/plugins/filter.js
+++ b/src/plugins/filter.js
@@ -1,0 +1,21 @@
+import prefix from '../prefix'
+import pascalize from '../pascalize'
+
+// filter has basic support in webkit without prefix for svg documents
+// but in other cases it might need a prefix. We can resort to value testing.
+// See https://developer.mozilla.org/de/docs/Web/CSS/filter
+export default {
+  noPrefill: ['filter'],
+  supportedProperty: (prop, style) => {
+    if (prop === 'filter' && prefix.js === 'Webkit') {
+      style.filter = 'grayscale(50%)'
+      const value = style.filter
+      style.filter = ''
+      if (value) return prop
+      if (prefix.js + pascalize(prop) in style) {
+        return prefix.css + prop
+      }
+    }
+    return false
+  }
+}

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,6 +1,7 @@
 import mask from './mask'
 import writingMode from './writing-mode'
 import clipPath from './clip-path'
+import filter from './filter'
 import unprefixed from './unprefixed'
 import prefixed from './prefixed'
 import blockLogicalOld from './block-logical-old'
@@ -12,6 +13,7 @@ const plugins = [
   mask,
   writingMode,
   clipPath,
+  filter,
   unprefixed,
   prefixed,
   blockLogicalOld,

--- a/test/fixtures/property-prefix.js
+++ b/test/fixtures/property-prefix.js
@@ -28,7 +28,9 @@ const isNotSupported = (o) =>
     o.property.match(/^mask-border-/) && o.notes.indexOf(3) > -1 ||
     // http://caniuse.com/#feat=text-decoration
     o.property === 'text-decoration-skip' && o.notes.indexOf(4) > -1 ||
-    o.property === 'text-decoration-style' && o.notes.indexOf(2) > -1
+    o.property === 'text-decoration-style' && o.notes.indexOf(2) > -1 ||
+    // http://caniuse.com/#feat=css-crisp-edges
+    o.property === 'image-rendering' && o.notes.indexOf(2) > -1
 
 function generateFixture() {
   const fixture = {}

--- a/test/fixtures/property-prefix.js
+++ b/test/fixtures/property-prefix.js
@@ -25,6 +25,7 @@ const isNotSupported = (o) =>
     o.property === 'column-fill' && o.notes.indexOf(2) > -1 ||
     // http://caniuse.com/#feat=css-masks
     o.property.match(/^mask-/) && o.notes.indexOf(2) > -1 ||
+    o.property.match(/^mask-border-/) && o.notes.indexOf(3) > -1 ||
     // http://caniuse.com/#feat=text-decoration
     o.property === 'text-decoration-skip' && o.notes.indexOf(4) > -1 ||
     o.property === 'text-decoration-style' && o.notes.indexOf(2) > -1

--- a/test/fixtures/property-prefix.js
+++ b/test/fixtures/property-prefix.js
@@ -11,6 +11,8 @@ const prefixer = postcssJs.sync([ap])
 const skipProperties = [
   // caniuse doesn't cover this property and spec might drop this: https://www.w3.org/TR/css-fonts-3/.
   'font-language-override',
+  // Lack of caniuse data. See https://github.com/Fyrd/caniuse/issues/2116
+  'font-variant-ligatures',
 ]
 
 const isNotSupported = (o) =>

--- a/test/fixtures/property-prefix.js
+++ b/test/fixtures/property-prefix.js
@@ -22,6 +22,7 @@ const isNotSupported = (o) =>
     // http://caniuse.com/#feat=multicolumn
     // https://bugzilla.mozilla.org/show_bug.cgi?id=616436
     o.property === 'column-span' && currentBrowser.id === 'firefox' ||
+    o.property === 'column-fill' && o.notes.indexOf(2) > -1 ||
     // http://caniuse.com/#feat=css-masks
     o.property.match(/^mask-/) && o.notes.indexOf(2) > -1 ||
     // http://caniuse.com/#feat=text-decoration

--- a/test/fixtures/property-prefix.js
+++ b/test/fixtures/property-prefix.js
@@ -30,7 +30,9 @@ const isNotSupported = (o) =>
     o.property === 'text-decoration-skip' && o.notes.indexOf(4) > -1 ||
     o.property === 'text-decoration-style' && o.notes.indexOf(2) > -1 ||
     // http://caniuse.com/#feat=css-crisp-edges
-    o.property === 'image-rendering' && o.notes.indexOf(2) > -1
+    o.property === 'image-rendering' && o.notes.indexOf(2) > -1 ||
+    // http://caniuse.com/#feat=css-logical-props
+    o.property.match(/^(border|margin|padding)-block-(start|end)/) && o.notes.indexOf(1) > -1
 
 function generateFixture() {
   const fixture = {}


### PR DESCRIPTION
With this PR our CI passes except for flex and IE + Edge issues.

- Support `filter` property for webkit/blink browsers
- Exclude `font-variant-ligatures` due to lack of caniuse data
- Exclude `column-fill` from browsers with no support
- Exclude `mask-border-*` props from browsers with no support
- Exclude `image-rendering` when not supported
- Exclude unsupported logical props from older firefox

Related PRs:
- https://github.com/Fyrd/caniuse/pull/3213
- https://github.com/Fyrd/caniuse/pull/3205
- https://github.com/Fyrd/caniuse/pull/3204
- https://github.com/Fyrd/caniuse/pull/3203
- https://github.com/Fyrd/caniuse/pull/3198
- https://github.com/postcss/autoprefixer/pull/795