### PR TITLE
Implement old flexbox for supportedProperty

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -29,9 +29,10 @@ describe('css-vendor', () => {
       expect(supportedProperty('display')).to.be('display')
     })
 
+    const opts = {multiple: true}
     for (const property in propertyPrefixFixture) {
       it(`should prefix ${property} if needed [${currentBrowser.id} ${currentBrowser.version}]`,
-        () => expect(supportedProperty(property)).to.be(propertyPrefixFixture[property]))
+        () => expect(supportedProperty(property, opts)).to.eql(propertyPrefixFixture[property]))
     }
 
     it('should return false', () => {

--- a/src/plugins/flex-old.js
+++ b/src/plugins/flex-old.js
@@ -1,0 +1,36 @@
+import prefix from '../prefix'
+import pascalize from '../pascalize'
+
+const propMap = {
+  flex: 'box-flex',
+  'flex-grow': 'box-flex',
+  'flex-direction': ['box-orient', 'box-direction'],
+  order: 'box-ordinal-group',
+  'align-items': 'box-align',
+  'flex-flow': ['box-orient', 'box-direction'],
+  'justify-content': 'box-pack',
+}
+
+const propKeys = Object.keys(propMap)
+
+const prefixCss = p => prefix.css + p
+
+// Support old flex spec from 2009.
+export default {
+  supportedProperty: (prop, style, {multiple}) => {
+    if (propKeys.indexOf(prop) > -1) {
+      const newProp = propMap[prop]
+      if (!Array.isArray(newProp)) {
+        return prefix.js + pascalize(newProp) in style ? prefix.css + newProp : false
+      }
+      if (!multiple) return false
+      for (let i = 0; i < newProp.length; i++) {
+        if (!(prefix.js + pascalize(newProp[0]) in style)) {
+          return false
+        }
+      }
+      return newProp.map(prefixCss)
+    }
+    return false
+  }
+}

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -8,6 +8,7 @@ import blockLogicalOld from './block-logical-old'
 import inlineLogicalOld from './inline-logical-old'
 import maskBorderOld from './mask-border-old'
 import breakPropsOld from './break-props-old'
+import flexOld from './flex-old'
 
 const plugins = [
   mask,
@@ -16,6 +17,7 @@ const plugins = [
   filter,
   unprefixed,
   prefixed,
+  flexOld,
   blockLogicalOld,
   inlineLogicalOld,
   maskBorderOld,

--- a/src/supported-property.js
+++ b/src/supported-property.js
@@ -31,10 +31,11 @@ if (isInBrowser) {
  * prefix if required. Returns `false` if not supported.
  *
  * @param {String} prop dash separated
+ * @param {Object} [options]
  * @return {String|Boolean}
  * @api public
  */
-export default function supportedProperty(prop) {
+export default function supportedProperty(prop, options = {}) {
   // For server-side rendering.
   if (!el) return prop
 
@@ -42,7 +43,7 @@ export default function supportedProperty(prop) {
   if (cache[prop] != null) return cache[prop]
 
   for (let i = 0; i < propertyDetectors.length; i++) {
-    cache[prop] = propertyDetectors[i](prop, el.style)
+    cache[prop] = propertyDetectors[i](prop, el.style, options)
     if (cache[prop]) break
   }
 

--- a/test/fixtures/property-prefix.js
+++ b/test/fixtures/property-prefix.js
@@ -15,6 +15,8 @@ const skipProperties = [
   'font-variant-ligatures',
 ]
 
+const flexOldUnsupported = ['flex-shrink', 'flex-basis', 'flex-wrap', 'align-self', 'align-content']
+
 const isNotSupported = (o) =>
     o.level === 'none' ||
     // http://caniuse.com/#feat=object-fit
@@ -32,7 +34,10 @@ const isNotSupported = (o) =>
     // http://caniuse.com/#feat=css-crisp-edges
     o.property === 'image-rendering' && o.notes.indexOf(2) > -1 ||
     // http://caniuse.com/#feat=css-logical-props
-    o.property.match(/^(border|margin|padding)-block-(start|end)/) && o.notes.indexOf(1) > -1
+    o.property.match(/^(border|margin|padding)-block-(start|end)/) && o.notes.indexOf(1) > -1 ||
+    // http://caniuse.com/#feat=flexbox
+    flexOldUnsupported.indexOf(o.property) > -1 && o.notes.indexOf(1) > -1 ||
+    ['flex-wrap', 'flex-flow', 'align-content'].indexOf(o.property) > -1 && o.notes.indexOf(3) > -1
 
 function generateFixture() {
   const fixture = {}

--- a/test/fixtures/property-prefix.js
+++ b/test/fixtures/property-prefix.js
@@ -49,7 +49,10 @@ function generateFixture() {
     // therefore we cannot test with the caniuse data for these cases.
     filter(o => !isNotSupported(o)).
     forEach(o => {
-      fixture[o.property] = dashify(Object.keys(prefixer({[o.property]: ''}))[0])
+      let props = Object.keys(prefixer({[o.property]: ''})).map(dashify)
+      // Remove unprefixed prop (last in array) when prefix is needed.
+      props = props.length > 1 ? props.slice(0, props.length - 1) : props
+      fixture[o.property] = props.length === 1 ? props[0] : props
     })
   return fixture
 }


### PR DESCRIPTION
This PR does the following:
- `supportedProperty` now accepts an optional `options` parameter
- Test fixture might include multiple properties for certain props
- implement old flexbox 2009 props for `supportedProperty`

This PR (and previous PRs) only implements the `supportedProperty` part and we still need to properly implement the `supportedValue` counterpart.

44 failing tests left (all IE and Edge related).