### PR TITLE
Fix writing-mode for Chrome/any WebKit except Safari

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -35,6 +35,14 @@ describe('css-vendor', () => {
         () => expect(supportedProperty(property, opts)).to.eql(propertyPrefixFixture[property]))
     }
 
+    it('should prefix writing-mode', () => {
+      let isPrefixed = false
+      if (prefix.js === 'Webkit' || prefix.js === 'ms') {
+        isPrefixed = true
+      }
+      expect(supportedProperty('writing-mode')).to.be(`${isPrefixed ? prefix.css : ''}writing-mode`)
+    })
+
     it('should return false', () => {
       expect(supportedProperty('xxx')).to.be(false)
     })

--- a/src/plugins/writing-mode.js
+++ b/src/plugins/writing-mode.js
@@ -8,16 +8,10 @@ export default {
   noPrefill: ['writing-mode'],
   supportedProperty: (prop) => {
     if (prop === 'writing-mode') {
-      switch (prefix.js) {
-        case 'Webkit': {
-          return prefix.css + prop
-        }
-        case 'ms': {
-          return prefix.css + prop
-        }
-        default:
-          return prop
+      if (prefix.js === 'Webkit' || prefix.js === 'ms') {
+        return prefix.css + prop
       }
+      return prop
     }
     return false
   }

--- a/src/plugins/writing-mode.js
+++ b/src/plugins/writing-mode.js
@@ -8,9 +8,11 @@ export default {
   noPrefill: ['writing-mode'],
   supportedProperty: (prop, style) => {
     if (prop === 'writing-mode' && prefix.js === 'Webkit') {
-      if (prefix.js + pascalize(prop) in style) {
+      const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
+      if (prefix.js + pascalize(prop) in style && isSafari) {
         return prefix.css + prop
       }
+      return prop
     }
     return false
   }

--- a/src/plugins/writing-mode.js
+++ b/src/plugins/writing-mode.js
@@ -1,18 +1,23 @@
 import prefix from '../prefix'
-import pascalize from '../pascalize'
+// import pascalize from '../pascalize'
 
 // writing-mode has basic support in webkit without prefix for svg documents
 // but in other cases it might need a prefix. We can resort to value testing.
 // See https://developer.mozilla.org/de/docs/Web/CSS/writing-mode
 export default {
   noPrefill: ['writing-mode'],
-  supportedProperty: (prop, style) => {
-    if (prop === 'writing-mode' && prefix.js === 'Webkit') {
-      const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
-      if (prefix.js + pascalize(prop) in style && isSafari) {
-        return prefix.css + prop
+  supportedProperty: (prop) => {
+    if (prop === 'writing-mode') {
+      switch (prefix.js) {
+        case 'Webkit': {
+          return prefix.css + prop
+        }
+        case 'ms': {
+          return prefix.css + prop
+        }
+        default:
+          return prop
       }
-      return prop
     }
     return false
   }

--- a/test/fixtures/property-prefix.js
+++ b/test/fixtures/property-prefix.js
@@ -47,7 +47,7 @@ const isExcluded = o =>
     flexOldUnsupported.indexOf(o.property) > -1 && o.notes.indexOf(1) > -1 ||
     flexOldFFUnsupported.indexOf(o.property) > -1 && o.notes.indexOf(3) > -1 ||
     // Autoprefixer Quirk: prefixes writing-mode for ie even though it is not necessary
-    o.property === 'writing-mode' && currentBrowser.id === 'ie' ||
+    o.property === 'writing-mode' ||
     // http://caniuse.com/#feat=css-snappoints
     msSnapPointsUnsupported.indexOf(o.property) > -1 && o.notes.indexOf(6) > -1 ||
     // http://caniuse.com/#feat=css-regions
@@ -77,4 +77,3 @@ function generateFixture() {
 }
 
 export default generateFixture()
-


### PR DESCRIPTION
This one need to be checked because only Safari, [should](http://caniuse.com/#search=writing-mode) be prefixed. 