### PR TITLE
Prevent error on invalid properties

### DIFF
--- a/src/supported-property.js
+++ b/src/supported-property.js
@@ -54,7 +54,12 @@ export default function supportedProperty(prop, options = {}) {
     if (cache[prop]) break
   }
 
-  el.style[prop] = ''
+  // Firefox can even throw an error for invalid properties, e.g. "0"
+  try {
+      el.style[prop] = '';
+  } catch (err) {
+      return false;
+  }
 
   return cache[prop]
 }


### PR DESCRIPTION
Firefox throws an exception if an invalid style property is set, e.g. el.style["0"]

The exception would be `TypeError: CSS2Properties doesn't have an indexed property setter for '0'`