### PR TITLE
fix for breaking complex transition values

### DIFF
--- a/src/supported-value.js
+++ b/src/supported-value.js
@@ -9,7 +9,7 @@ const transitionProperties = {
   '-webkit-transition': 1,
   '-webkit-transition-property': 1
 }
-const transPropsRegExp = /(^\s*\w+)|, (\s*\w+)/g
+const transPropsRegExp = /(^\s*\w+)|, (\s*\w+)(?![^()]*\))/g
 let el
 
 function prefixTransitionCallback(match, p1, p2) {

--- a/src/supported-value.test.js
+++ b/src/supported-value.test.js
@@ -39,5 +39,10 @@ describe('css-vendor', () => {
       expect(supportedValue('transition', 'all 100ms ease, transform 200ms linear'))
         .to.eql(`all 100ms ease, ${propertyPrefixFixture.transform} 200ms linear`)
     })
+
+    it('should not break a complex transition value', () => {
+      const value = 'margin 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms'
+      expect(supportedValue('transition', value)).to.be(value)
+    })
   })
 })


### PR DESCRIPTION
**why:**
fixes https://github.com/cssinjs/jss/issues/661

**how:**
`transPropsRegExp` no longer matches values that are inside parentheses.