### PR TITLE
-webkit-backdrop-filter required on Microsoft Edge

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/css-vendor.js": {
-    "bundled": 16489,
-    "minified": 5279,
-    "gzipped": 2012
+    "bundled": 16502,
+    "minified": 5290,
+    "gzipped": 2016
   },
   "dist/css-vendor.min.js": {
-    "bundled": 16489,
-    "minified": 5279,
-    "gzipped": 2012
+    "bundled": 16502,
+    "minified": 5290,
+    "gzipped": 2016
   },
   "./lib/index": {
     "bundled": 14406,
@@ -15,21 +15,21 @@
     "gzipped": 2186
   },
   "./dist/css-vendor.cjs.js": {
-    "bundled": 14578,
-    "minified": 6146,
-    "gzipped": 2097
+    "bundled": 14591,
+    "minified": 6157,
+    "gzipped": 2100
   },
   "./dist/css-vendor.esm.js": {
-    "bundled": 14259,
-    "minified": 5885,
-    "gzipped": 2008,
+    "bundled": 14272,
+    "minified": 5896,
+    "gzipped": 2011,
     "treeshaked": {
       "rollup": {
-        "code": 3276,
+        "code": 3287,
         "import_statements": 89
       },
       "webpack": {
-        "code": 4470
+        "code": 4481
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/core": "^7.2.2",
     "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.2.3",
-    "autoprefixer": "^9.5.0",
+    "autoprefixer": "^9.5.1",
     "babel-cli": "^6.5.1",
     "babel-eslint": "^9.0.0",
     "babel-loader": "^8.0.5",

--- a/src/plugins/prefixed.js
+++ b/src/plugins/prefixed.js
@@ -7,7 +7,7 @@ export default {
     const pascalized = pascalize(prop)
     if (prefix.js + pascalized in style) return prefix.css + prop
     // Try webkit fallback.
-    if (prefix.js !== 'Webkit' && `Webkit${pascalized}` in style) return prop
+    if (prefix.js !== 'Webkit' && `Webkit${pascalized}` in style) return `-webkit-${prop}`
     return false
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -936,13 +936,13 @@ atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
 
-autoprefixer@^9.5.0:
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.5.0.tgz#7e51d0355c11596e6cf9a0afc9a44e86d1596c70"
-  integrity sha512-hMKcyHsZn5+qL6AUeP3c8OyuteZ4VaUlg+fWbyl8z7PqsKHF/Bf8/px3K6AT8aMzDkBo8Bc11245MM+itDBOxQ==
+autoprefixer@^9.5.1:
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.5.1.tgz#243b1267b67e7e947f28919d786b50d3bb0fb357"
+  integrity sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==
   dependencies:
-    browserslist "^4.4.2"
-    caniuse-lite "^1.0.30000947"
+    browserslist "^4.5.4"
+    caniuse-lite "^1.0.30000957"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
     postcss "^7.0.14"
@@ -1346,14 +1346,14 @@ browserslist@^4.3.4:
     electron-to-chromium "^1.3.103"
     node-releases "^1.1.3"
 
-browserslist@^4.4.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.5.2.tgz#36ad281f040af684555a23c780f5c2081c752df0"
-  integrity sha512-zmJVLiKLrzko0iszd/V4SsjTaomFeoVzQGYYOYgRgsbh7WNh95RgDB0CmBdFWYs/3MyFSt69NypjL/h3iaddKQ==
+browserslist@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.5.4.tgz#166c4ecef3b51737a42436ea8002aeea466ea2c7"
+  integrity sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==
   dependencies:
-    caniuse-lite "^1.0.30000951"
-    electron-to-chromium "^1.3.116"
-    node-releases "^1.1.11"
+    caniuse-lite "^1.0.30000955"
+    electron-to-chromium "^1.3.122"
+    node-releases "^1.1.13"
 
 browserstack@~1.5.1:
   version "1.5.2"
@@ -1492,10 +1492,15 @@ caniuse-lite@^1.0.30000929:
   version "1.0.30000935"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000935.tgz#d1b59df00b46f4921bb84a8a34c1d172b346df59"
 
-caniuse-lite@^1.0.30000947, caniuse-lite@^1.0.30000951:
+caniuse-lite@^1.0.30000951:
   version "1.0.30000951"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000951.tgz#c7c2fd4d71080284c8677dd410368df8d83688fe"
   integrity sha512-eRhP+nQ6YUkIcNQ6hnvdhMkdc7n3zadog0KXNRxAZTT2kHjUb1yGn71OrPhSn8MOvlX97g5CR97kGVj8fMsXWg==
+
+caniuse-lite@^1.0.30000955, caniuse-lite@^1.0.30000957:
+  version "1.0.30000957"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000957.tgz#fb1026bf184d7d62c685205358c3b24b9e29f7b3"
+  integrity sha512-8wxNrjAzyiHcLXN/iunskqQnJquQQ6VX8JHfW5kLgAPRSiSuKZiNfmIkP5j7jgyXqAQBSoXyJxfnbCFS0ThSiQ==
 
 caniuse-support@^1.0.1:
   version "1.0.1"
@@ -2065,10 +2070,10 @@ electron-to-chromium@^1.3.103:
   version "1.3.113"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz#b1ccf619df7295aea17bc6951dc689632629e4a9"
 
-electron-to-chromium@^1.3.116:
-  version "1.3.118"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.118.tgz#5c82b0445a40934e6cae9c2f40bfaaa986ea44a3"
-  integrity sha512-/1FpHvmKmKo2Z6CCza2HfkrKvKhU7Rq4nvyX1FOherdTrdTufhVrJbCrcrIqgqUCI+BG6JC2rlY4z5QA1G0NOw==
+electron-to-chromium@^1.3.122:
+  version "1.3.124"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.124.tgz#861fc0148748a11b3e5ccebdf8b795ff513fa11f"
+  integrity sha512-glecGr/kFdfeXUHOHAWvGcXrxNU+1wSO/t5B23tT1dtlvYB26GY8aHzZSWD7HqhqC800Lr+w/hQul6C5AF542w==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -4187,10 +4192,10 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.11:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.11.tgz#9a0841a4b0d92b7d5141ed179e764f42ad22724a"
-  integrity sha512-8v1j5KfP+s5WOTa1spNUAOfreajQPN12JXbRR0oDE+YrJBQCXBnNqUDj27EKpPLOoSiU3tKi3xGPB+JaOdUEQQ==
+node-releases@^1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.13.tgz#8c03296b5ae60c08e2ff4f8f22ae45bd2f210083"
+  integrity sha512-fKZGviSXR6YvVPyc011NHuJDSD8gFQvLPmc2d2V3BS4gr52ycyQ1Xzs7a8B+Ax3Ni/W+5h1h4SqmzeoA8WZRmA==
   dependencies:
     semver "^5.3.0"
 


### PR DESCRIPTION
In the current release `supportedProperty('backdrop-filter')` returns `'backdrop-filter'` on Edge, but that browser requires `-webkit-backdrop-filter`.

This case is handled by the `prefixed` plugin, which tries the webkit prefix as a fallback if the browser’s own prefix (`ms` in this case) is not supported. The fallback works correctly in this case, but it returns the original value of `prop`. This line of code used to be `` `-webkit-${prop}` `` but the `-webkit` part was removed in PR #26.

This PR restores the `-webkit` prefix, which works for me to get `backdrop-filter` working in MS Edge. There are a couple of things I'm unsure of though:

1. This probably needs a unit test, but I'm not sure how to go about adding one. I don't have a BrowserStack account to be able try the `USE_CLOUD` configuration and see what happens when it runs on Edge, or whether the `backdrop-filter` style is already included by `generateFixture()`.
2. I don’t know why the `-webkit` prefix was removed from the fallback in #26. That PR was about transition/transform, both of which have their own plugins, so I don't think the `prefixed` plugin would be executed at all for those styles. This comment was also deleted at the same time: `// E.g. appearance in Edge & IE Mobile needs a -webkit- prefix.`. Do you remember the context here @AleshaOleg ?