### PR TITLE
Add support for "hyphens" CSS property

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/css-vendor.js": {
-    "bundled": 17055,
-    "minified": 5599,
-    "gzipped": 2131
+    "bundled": 17450,
+    "minified": 5771,
+    "gzipped": 2169
   },
   "dist/css-vendor.min.js": {
-    "bundled": 17055,
-    "minified": 5599,
-    "gzipped": 2131
+    "bundled": 17450,
+    "minified": 5771,
+    "gzipped": 2169
   },
   "./lib/index": {
     "bundled": 14406,
@@ -34,21 +34,21 @@
     }
   },
   "dist/css-vendor.cjs.js": {
-    "bundled": 15122,
-    "minified": 6466,
-    "gzipped": 2175
+    "bundled": 15493,
+    "minified": 6677,
+    "gzipped": 2213
   },
   "dist/css-vendor.esm.js": {
-    "bundled": 14803,
-    "minified": 6205,
-    "gzipped": 2084,
+    "bundled": 15174,
+    "minified": 6416,
+    "gzipped": 2121,
     "treeshaked": {
       "rollup": {
-        "code": 3500,
+        "code": 3651,
         "import_statements": 89
       },
       "webpack": {
-        "code": 4717
+        "code": 4877
       }
     }
   }

--- a/src/plugins/hyphens.js
+++ b/src/plugins/hyphens.js
@@ -1,0 +1,14 @@
+import prefix from '../prefix'
+
+// Support hyphens prop syntax.
+// https://caniuse.com/#search=hyphens
+export default {
+  noPrefill: ['hyphens'],
+  supportedProperty: (prop) => {
+    if (prop !== 'hyphens') return false
+    if (prefix.vendor === 'apple' || (prefix.js === 'ms' && prefix.browser !== 'edge')) {
+      return prefix.css + prop
+    }
+    return prop
+  }
+}

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -14,6 +14,7 @@ import scrollSnap from './scroll-snap'
 import overscrollBehavior from './overscroll-behavior'
 import flex2012 from './flex-2012'
 import flex2009 from './flex-2009'
+import hyphens from './hyphens'
 
 // Please, keep order plugins:
 // plugins = [
@@ -39,6 +40,7 @@ const plugins = [
   transition,
   writingMode,
   userSelect,
+  hyphens,
   breakPropsOld,
   inlineLogicalOld,
   unprefixed,
@@ -50,11 +52,11 @@ const plugins = [
 ]
 
 export const propertyDetectors = plugins
-  .filter(p => p.supportedProperty)
-  .map(p => p.supportedProperty)
+  .filter((p) => p.supportedProperty)
+  .map((p) => p.supportedProperty)
 
 export const noPrefill = plugins
-  .filter(p => p.noPrefill)
+  .filter((p) => p.noPrefill)
   .reduce((a, p) => {
     a.push(...p.noPrefill)
     return a


### PR DESCRIPTION
As specified here: https://caniuse.com/#search=hyphens, it should be prefixed on IE and Safari

Signed-off-by: Fabien Caylus <fabien.caylus@gmail.com>