### PR TITLE
Method supportedValue should support !important property.

### DIFF
--- a/src/supported-value.js
+++ b/src/supported-value.js
@@ -64,7 +64,7 @@ export default function supportedValue(property, value) {
   // IE can even throw an error in some cases, for e.g. style.content = 'bar'.
   try {
     // Test value as it is.
-    el.style[property] = prefixedValue
+    el.style.setProperty(property, ...prefixedValue.split(/!(?=important$)/))
   } catch (err) {
     // Return false if value not supported.
     cache[cacheKey] = false

--- a/src/supported-value.test.js
+++ b/src/supported-value.test.js
@@ -78,5 +78,16 @@ describe('css-vendor', () => {
         prefix.js === 'ms' && prefix.browser !== 'edge' ? false : value
       )
     })
+
+    it('should support !important property', () => {
+      expect(supportedValue('border', 'solid 1px indigo !important')).to.be(
+        'solid 1px indigo !important'
+      )
+      expect(supportedValue('font-size', '12px!important')).to.be('12px!important')
+    })
+
+    it('should support content property with the value contains !important string', () => {
+      expect(supportedValue('content', '!important')).to.be('!important')
+    })
   })
 })


### PR DESCRIPTION
- Using the `el.style.setProperty(property, value, priority)` method instead of using `el.style[property] = value` to fix #214 .
- Adding test cases for this issue.