### PR TITLE
 Check document.documentElement - part 2

### DIFF
--- a/src/supported-property.js
+++ b/src/supported-property.js
@@ -4,7 +4,7 @@ import {propertyDetectors, noPrefill} from './plugins/index'
 let el
 const cache = {}
 
-if (isInBrowser) {
+if (isInBrowser && document.documentElement) {
   el = document.createElement('p')
 
   // We test every property on vendor prefix requirement.


### PR DESCRIPTION
Prevent TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.

Continuation of #218 